### PR TITLE
Add 'realistic-thrust-50%' custom data overrides, allowing opt-out ships

### DIFF
--- a/Data/Scripts/RealisticThrusters/RealisticThrustersMod.cs
+++ b/Data/Scripts/RealisticThrusters/RealisticThrustersMod.cs
@@ -14,6 +14,7 @@ namespace Digi.RealisticThrusters
     public class RealisticThrustersMod : MySessionComponentBase
     {
         public const string CUSTOMDATA_FORCE_TAG = "force-realistic-thrust";
+        public const string CUSTOMDATA_DISABLE_TAG = "disable-realistic-thrust";
 
         public static RealisticThrustersMod Instance;
 

--- a/Data/Scripts/RealisticThrusters/Thruster.cs
+++ b/Data/Scripts/RealisticThrusters/Thruster.cs
@@ -12,7 +12,7 @@ namespace Digi.RealisticThrusters
     public class Thruster : MyGameLogicComponent
     {
         public MyThrust Block;
-        bool RealisticMode = true;
+        float RealismAmount = 1.0f;
 
         public override void Init(MyObjectBuilder_EntityBase objectBuilder)
         {
@@ -27,14 +27,14 @@ namespace Digi.RealisticThrusters
 
         void WorkingChanged(MyCubeBlock obj)
         {
-            SetRealisticMode(RealisticMode);
+            SetRealismAmount(RealismAmount);
         }
 
-        public void SetRealisticMode(bool realisticMode)
+        public void SetRealismAmount(float realismAmount)
         {
-            RealisticMode = realisticMode;
+            RealismAmount = realismAmount;
 
-            if(RealisticMode && Block.IsWorking)
+            if(RealismAmount > 0.001f && Block.IsWorking)
                 NeedsUpdate |= MyEntityUpdateEnum.EACH_FRAME;
             else
                 NeedsUpdate &= ~MyEntityUpdateEnum.EACH_FRAME;
@@ -44,14 +44,14 @@ namespace Digi.RealisticThrusters
         {
             try
             {
-                if(!RealisticMode || !Block.IsWorking)
+                if(RealismAmount <= 0.001f || !Block.IsWorking)
                     return;
 
                 var grid = Block.CubeGrid;
                 if(grid.IsPreview || grid.Physics == null || !grid.Physics.Enabled || grid.Physics.IsStatic)
                     return;
 
-                float strength = Block.BlockDefinition.ForceMagnitude * Block.CurrentStrength;
+                float strength = Block.BlockDefinition.ForceMagnitude * Block.CurrentStrength * RealismAmount;
 
                 if(Math.Abs(strength) < 0.00001f)
                     return;


### PR DESCRIPTION
This expands the `force-realistic-thrust` CustomData flag functionality, which you originally intended only for opting-in NPC ships, by allowing `realistic-thrust-0%` or custom `realistic-thrust-75%` overrides.

This allows players to opt-out of using Realistic Thrust on a per-ship basis.

I love the offset thrust model this mod provides, but I play with friends who just want to build pretty museum pieces that make no dang sense engineering-wise, who demand I turn the mod off so their nonsense can fly straight. This lets those ships opt-out via `realistic-thrust-0%` in their CustomData.

Looking for alternative mods, I saw https://steamcommunity.com/sharedfiles/filedetails/?id=2383340737 supports a server-wide setting of 50% (compromise between vanilla and this mod's offset), which many players reported was "less hard" - so I chose to move from a `bool` to a `float` for the CustomData override.